### PR TITLE
Add hlint check, remove type applications as default extension

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,3 +27,9 @@ jobs:
 
       - name: Check formatting
         run: make format-check
+
+      - name: Install hlint
+        run: stack install hlint
+
+      - name: Check hints
+        run: make hlint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,14 +22,11 @@ jobs:
       - name: Run tests
         run: stack test
 
-      - name: Install fourmolu
-        run: stack install fourmolu
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
 
       - name: Check formatting
-        run: make format-check
-
-      - name: Install hlint
-        run: stack install hlint
+        run: nix-shell -p pkgs.haskellPackages.fourmolu --command 'make format-check'
 
       - name: Check hints
-        run: make hlint
+        run: nix-shell -p pkgs.haskellPackages.hlint --command 'make hlint'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Check formatting
         run: nix-shell -p haskellPackages.fourmolu --command 'make format-check'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: cachix/install-nix-action@v16
 
       - name: Check formatting
-        run: nix-shell -p pkgs.haskellPackages.fourmolu --command 'make format-check'
+        run: nix-shell -p haskellPackages.fourmolu --command 'make format-check'
 
       - name: Check hints
-        run: nix-shell -p pkgs.haskellPackages.hlint --command 'make hlint'
+        run: nix-shell -p haskellPackages.hlint --command 'make hlint'

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,7 @@ ghcid:
 clean:
 	stack clean
 
-.PHONY: build test format format-check ghcid clean
+hlint:
+	hlint .
+
+.PHONY: build test format format-check ghcid clean hlint

--- a/package.yaml
+++ b/package.yaml
@@ -31,7 +31,6 @@ default-extensions:
 - ImportQualifiedPost
 - LambdaCase
 - OverloadedStrings
-- TypeApplications
 
 library:
   source-dirs: src

--- a/snailscheme.cabal
+++ b/snailscheme.cabal
@@ -35,7 +35,6 @@ library
       ImportQualifiedPost
       LambdaCase
       OverloadedStrings
-      TypeApplications
   build-depends:
       base >=4.7 && <5
     , containers
@@ -55,7 +54,6 @@ executable snailscheme-exe
       ImportQualifiedPost
       LambdaCase
       OverloadedStrings
-      TypeApplications
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
@@ -80,7 +78,6 @@ test-suite snailscheme-test
       ImportQualifiedPost
       LambdaCase
       OverloadedStrings
-      TypeApplications
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       QuickCheck

--- a/test/Snail/LexerSpec.hs
+++ b/test/Snail/LexerSpec.hs
@@ -30,10 +30,10 @@ spec = do
   describe "Signed and unsigned integers" $ do
     let tshow = T.pack . show
     it "successfully parses positive and negative integers" $ do
-      forAll (arbitrary @Integer) $
+      forAll arbitrary $
         \i -> parseMaybe signedInteger (tshow i) `shouldBe` Just i
     it "successfully parses positive signed integers" $ do
-      forAll (arbitrary @Integer) $
+      forAll arbitrary $
         \i -> parseMaybe signedInteger ("+ " <> tshow (abs i)) `shouldBe` Just (abs i)
 
   describe "Parsing parens" $ do


### PR DESCRIPTION
Remove TypeApplications to avoid confusion for beginners. Replace `stack install {fourmolu,hlint}` with nix to speed up CI. Note, I am not adding any nix stuff for local development.